### PR TITLE
Added option to append PATH to runtime

### DIFF
--- a/src/main/kotlin/com/nanovms/ops/Ops.kt
+++ b/src/main/kotlin/com/nanovms/ops/Ops.kt
@@ -1,0 +1,9 @@
+package com.nanovms.ops
+
+import com.intellij.openapi.components.service
+
+object Ops {
+    val instance by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        service<Service>()
+    }
+}

--- a/src/main/kotlin/com/nanovms/ops/Service.kt
+++ b/src/main/kotlin/com/nanovms/ops/Service.kt
@@ -5,9 +5,7 @@ import com.intellij.openapi.project.Project
 import com.nanovms.ops.command.Command
 
 interface Service: Disposable {
-    fun hasImages(): Boolean
     fun listImages(): Array<String>
-    fun hasInstances(): Boolean
     fun listInstances(): Array<String>
     val isInstalled: Boolean
 

--- a/src/main/kotlin/com/nanovms/ops/Service.kt
+++ b/src/main/kotlin/com/nanovms/ops/Service.kt
@@ -15,5 +15,7 @@ interface Service: Disposable {
     fun releaseCommand(command: Command)
     fun runningExecutables(): Collection<Command>
 
+    val settings: Settings
+
     fun println(project: Project, vararg texts: String)
 }

--- a/src/main/kotlin/com/nanovms/ops/Service.kt
+++ b/src/main/kotlin/com/nanovms/ops/Service.kt
@@ -1,5 +1,6 @@
 package com.nanovms.ops
 
+import com.intellij.execution.process.OSProcessHandler
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.nanovms.ops.command.Command
@@ -16,4 +17,6 @@ interface Service: Disposable {
     val settings: Settings
 
     fun println(project: Project, vararg texts: String)
+
+    fun execute(vararg args: String): OSProcessHandler
 }

--- a/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
+++ b/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
@@ -110,7 +110,9 @@ class ServiceDefault() : Service {
             cmd += " $arg"
         }
 
-        return Runtime.getRuntime().exec(cmd, arrayOf("PATH=${settings.getMergedPaths()}"))
+        val pathList = settings.getMergedPaths()
+        println("[OPS] Execute \"${cmd}\" with PATH=${pathList}")
+        return Runtime.getRuntime().exec(cmd, arrayOf("PATH=${pathList}"))
     }
 
     private fun readStream(input: InputStream): String {

--- a/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
+++ b/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
@@ -1,5 +1,6 @@
 package com.nanovms.ops
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.nanovms.ops.command.Command
 import com.nanovms.ops.command.CommandType
@@ -77,6 +78,8 @@ class ServiceDefault() : Service {
         return list.toImmutableList()
     }
 
+    override val settings = service<Settings>()
+
     override fun println(project: Project, vararg texts: String) {
         ToolWindowFactory.println(project, texts.joinToString(" "))
     }
@@ -106,7 +109,8 @@ class ServiceDefault() : Service {
         for (arg in args) {
             cmd += " $arg"
         }
-        return Runtime.getRuntime().exec(cmd)
+
+        return Runtime.getRuntime().exec(cmd, arrayOf("PATH=${settings.getMergedPaths()}"))
     }
 
     private fun readStream(input: InputStream): String {

--- a/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
+++ b/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
@@ -9,32 +9,12 @@ import okhttp3.internal.toImmutableList
 import java.io.*
 
 class ServiceDefault() : Service {
-    override fun hasImages(): Boolean {
-        val proc = execute("image", "list")
-        if (proc.waitFor() != 0) {
-            throw Exception(readStream(proc.errorStream))
-        }
-        val output = readStream(proc.inputStream)
-        val lines = output.split('\n')
-        return lines.size > 3
-    }
-
     override fun listImages(): Array<String> {
         val proc = execute("image", "list")
         if (proc.waitFor() != 0) {
             throw Exception(readStream(proc.errorStream))
         }
         return extractTableOutput(readStream(proc.inputStream), 1)
-    }
-
-    override fun hasInstances(): Boolean {
-        val proc = execute("instance", "list")
-        if (proc.waitFor() != 0) {
-            throw Exception(readStream(proc.errorStream))
-        }
-        val output = readStream(proc.inputStream)
-        val lines = output.split('\n')
-        return lines.size > 3
     }
 
     override fun listInstances(): Array<String> {

--- a/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
+++ b/src/main/kotlin/com/nanovms/ops/ServiceDefault.kt
@@ -8,7 +8,7 @@ import com.nanovms.ops.ui.ToolWindowFactory
 import okhttp3.internal.toImmutableList
 import java.io.*
 
-class ServiceDefault() : Service {
+class ServiceDefault : Service {
     override fun listImages(): Array<String> {
         val proc = execute("image", "list")
         if (proc.waitFor() != 0) {
@@ -97,11 +97,9 @@ class ServiceDefault() : Service {
 
     private fun readStream(input: InputStream): String {
         val reader = BufferedReader(InputStreamReader(input))
-        var output: String
-        try {
-            output = reader.readText()
-        } finally {
-            reader.close()
+        val output: String
+        reader.use {
+            output = it.readText()
         }
         return output.trim()
     }
@@ -114,7 +112,7 @@ class ServiceDefault() : Service {
     private fun extractTableOutput(output: String, colIndex: Int): Array<String> {
         val rows = mutableListOf<String>()
         val lines = output.split('\n')
-        if (lines.size === 3) {
+        if (lines.size == 3) {
             return arrayOf() // no image listed
         }
 
@@ -138,6 +136,6 @@ class ServiceDefault() : Service {
             }
             rows.add(value)
         }
-        return rows.toTypedArray();
+        return rows.toTypedArray()
     }
 }

--- a/src/main/kotlin/com/nanovms/ops/Settings.kt
+++ b/src/main/kotlin/com/nanovms/ops/Settings.kt
@@ -1,0 +1,33 @@
+package com.nanovms.ops
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+import java.io.File
+
+@State(
+    name = "com.nanovms.ops.Settings",
+    storages = [Storage("nanovms-ops.xml")]
+)
+class Settings: PersistentStateComponent<Settings> {
+    var additionalPaths = ""
+
+    fun getMergedPaths(): String {
+        var merged = systemPaths
+        if(merged.endsWith(File.pathSeparatorChar)) {
+            return systemPaths + additionalPaths
+        }
+        return systemPaths + File.pathSeparator + additionalPaths
+    }
+
+    override fun getState(): Settings? {
+        return this
+    }
+
+    override fun loadState(state: Settings) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    private val systemPaths = System.getenv("PATH")
+}

--- a/src/main/kotlin/com/nanovms/ops/action/StartInstanceAction.kt
+++ b/src/main/kotlin/com/nanovms/ops/action/StartInstanceAction.kt
@@ -4,20 +4,22 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
 import com.nanovms.ops.ui.DropdownDialog
 import com.nanovms.ops.Log
+import com.nanovms.ops.Ops
 import com.nanovms.ops.Service
 import com.nanovms.ops.command.Command
 import com.nanovms.ops.command.CommandListener
 import com.nanovms.ops.command.StartInstanceCommand
 
 class StartInstanceAction : BaseAction() {
-    override fun isEnabled(e: AnActionEvent, ops: Service): Boolean {
-        return ops.hasImages()
-    }
-
     override fun actionPerformed(e: AnActionEvent) {
         e.project?.let {
-            val ops = service<Service>()
-            val dialog = DropdownDialog(ops.listImages())
+            val images = Ops.instance.listImages()
+            if(images.isEmpty()) {
+                Log.notifyError(it, "You don't have one or more image to run, please create one using [Tool | NanoVMs | Build] menu.")
+                return
+            }
+
+            val dialog = DropdownDialog(images)
             val isOK = dialog.showAndGet()
             if (isOK) {
                 val selectedImage = dialog.model.selectedItem as String

--- a/src/main/kotlin/com/nanovms/ops/action/StopInstanceAction.kt
+++ b/src/main/kotlin/com/nanovms/ops/action/StopInstanceAction.kt
@@ -2,19 +2,22 @@ package com.nanovms.ops.action
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
+import com.nanovms.ops.Log
+import com.nanovms.ops.Ops
 import com.nanovms.ops.ui.DropdownDialog
 import com.nanovms.ops.Service
 import com.nanovms.ops.command.StopInstanceCommand
 
 class StopInstanceAction : BaseAction() {
-    override fun isEnabled(e: AnActionEvent, ops: Service): Boolean {
-        return ops.hasInstances()
-    }
-
     override fun actionPerformed(e: AnActionEvent) {
         e.project?.let {
-            val ops = service<Service>()
-            val dialog = DropdownDialog(ops.listInstances(), null)
+            val instances = Ops.instance.listInstances()
+            if(instances.isEmpty()) {
+                Log.notifyError(it, "You don't have one or more running instances. To run one, please use [Tool | NanoVMs | Start Instance] menu.")
+                return
+            }
+
+            val dialog = DropdownDialog(instances, null)
             val isOK = dialog.showAndGet()
             if (isOK) {
                 val instanceName = dialog.model.selectedItem as String

--- a/src/main/kotlin/com/nanovms/ops/command/Command.kt
+++ b/src/main/kotlin/com/nanovms/ops/command/Command.kt
@@ -3,6 +3,7 @@ package com.nanovms.ops.command
 import com.intellij.execution.process.OSProcessHandler
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.nanovms.ops.Ops
 import com.nanovms.ops.Service
 import java.io.File
 import java.io.InputStream
@@ -55,7 +56,9 @@ abstract class Command(val project: Project) {
         }
         command += " --show-debug"
 
-        _processHandler = OSProcessHandler(Runtime.getRuntime().exec(command), command, Charsets.UTF_8)
+        val pathList = Ops.instance.settings.getMergedPaths()
+        println("[OPS] Execute \"${command}\" with PATH=${pathList}")
+        _processHandler = OSProcessHandler(Runtime.getRuntime().exec(command, arrayOf("PATH=${pathList}")), command, Charsets.UTF_8)
         _processHandler.setShouldDestroyProcessRecursively(true)
         _processHandler?.addProcessListener(CommandProcessListener(this))
         _processHandler?.startNotify()

--- a/src/main/kotlin/com/nanovms/ops/command/Command.kt
+++ b/src/main/kotlin/com/nanovms/ops/command/Command.kt
@@ -7,6 +7,7 @@ import com.nanovms.ops.Ops
 import com.nanovms.ops.Service
 import java.io.File
 import java.io.InputStream
+import java.io.OutputStream
 
 enum class CommandType {
     RunExecutable,
@@ -31,6 +32,9 @@ abstract class Command(val project: Project) {
 
     val inputStream: InputStream
         get() = _processHandler.process.inputStream
+
+    val errorStream: InputStream
+        get() = _processHandler.process.errorStream
 
     private var _listener: CommandListener? = null
     val listener: CommandListener?

--- a/src/main/kotlin/com/nanovms/ops/command/CommandMonitor.kt
+++ b/src/main/kotlin/com/nanovms/ops/command/CommandMonitor.kt
@@ -3,6 +3,7 @@ package com.nanovms.ops.command
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.nanovms.ops.Service
+import kotlinx.coroutines.delay
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -11,12 +12,22 @@ class CommandMonitor(private val project: Project, private val command: Command)
     override fun run() {
         val ops = service<Service>()
         val reader = BufferedReader(InputStreamReader(command.inputStream))
+        val errReader = BufferedReader(InputStreamReader(command.errorStream))
         var line: String?
         while (command.isAlive) {
             try {
-                line = reader.readLine()
-                line?.let {
-                    ops.println(project, it)
+                if(reader.ready()) {
+                    line = reader.readLine()
+                    line?.let {
+                        ops.println(project, it)
+                    }
+                }
+
+                if(errReader.ready()) {
+                    line = errReader.readLine()
+                    line?.let {
+                        ops.println(project, it)
+                    }
                 }
             } catch (ex: IOException) {
                 // At this point stream already closed by the process,

--- a/src/main/kotlin/com/nanovms/ops/ui/ConfigurableSettings.kt
+++ b/src/main/kotlin/com/nanovms/ops/ui/ConfigurableSettings.kt
@@ -1,0 +1,26 @@
+package com.nanovms.ops.ui
+
+import com.intellij.openapi.options.Configurable
+import com.nanovms.ops.Ops
+import javax.swing.JComponent
+
+class ConfigurableSettings: Configurable {
+    override fun createComponent(): JComponent? {
+        return panel
+    }
+
+    override fun isModified(): Boolean {
+        return panel.text != Ops.instance.settings.additionalPaths
+    }
+
+    override fun apply() {
+        val settings = Ops.instance.settings
+        settings.additionalPaths = panel.text
+    }
+
+    override fun getDisplayName(): String {
+        return "NanoVMs"
+    }
+
+    private val panel = ConfigurableSettingsPanel()
+}

--- a/src/main/kotlin/com/nanovms/ops/ui/ConfigurableSettingsPanel.kt
+++ b/src/main/kotlin/com/nanovms/ops/ui/ConfigurableSettingsPanel.kt
@@ -1,0 +1,46 @@
+package com.nanovms.ops.ui
+
+import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.JBTextField
+import com.nanovms.ops.Ops
+import java.awt.*
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class ConfigurableSettingsPanel : JBPanel<ConfigurableSettingsPanel>() {
+    var text: String
+        get() {
+            return pathTextField.text
+        }
+        set(value) {
+            pathTextField.text = value
+        }
+
+    private var pathTextField = JBTextField()
+
+    init {
+        layout = BorderLayout()
+
+        val rootPane = JPanel(GridLayout(2, 1))
+
+        val pathHeaderPane = JPanel(FlowLayout(FlowLayout.LEADING, 0, 5))
+        pathHeaderPane.alignmentX = LEFT_ALIGNMENT
+        pathHeaderPane.add(JLabel("Following paths will be appended to runtime PATH. Use colon character (:) as separator between paths."))
+        rootPane.add(pathHeaderPane)
+
+        val cs = GridBagConstraints()
+        cs.fill = GridBagConstraints.HORIZONTAL
+        cs.ipadx = 10
+        val pathFormPane = JPanel(GridBagLayout())
+        pathFormPane.add(JLabel("PATH: "), cs)
+
+        cs.gridx = 1
+        cs.weightx = 1.0
+        pathFormPane.add(pathTextField, cs)
+        rootPane.add(pathFormPane)
+
+        add(rootPane, BorderLayout.PAGE_START)
+
+        text = Ops.instance.settings.additionalPaths
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,10 +29,7 @@
 
     <change-notes>
         <![CDATA[
-            <ul>
-                <li>Added tool window to display OPS output</li>
-                <li>Fixed few menu actions that enabled when no project opened</li>
-            </ul>
+            Added settings to extend runtime PATH.
         ]]>
     </change-notes>
 
@@ -43,10 +40,17 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceInterface="com.nanovms.ops.Service"
                             serviceImplementation="com.nanovms.ops.ServiceDefault"/>
+        <applicationService serviceImplementation="com.nanovms.ops.Settings"/>
+
 
         <notificationGroup displayType="BALLOON" id="NanoVMs"/>
 
         <toolWindow id="NanoVMs" anchor="bottom" factoryClass="com.nanovms.ops.ui.ToolWindowFactory"/>
+
+        <applicationConfigurable parentId="tools"
+                                 instance="com.nanovms.ops.ui.ConfigurableSettings"
+                                 id="com.nanovms.ops.ui.ConfigurableSettings"
+                                 displayName="NanoVMs"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
![Screenshot from 2021-06-20 06-41-15](https://user-images.githubusercontent.com/13412168/122658089-616f1680-d193-11eb-92f1-e50b188fe224.png)

On each ops command execution, `PATH` will be manually passed, which value is from system `PATH` appended with the additional paths defined in settings page.